### PR TITLE
Fix sheet value in api call

### DIFF
--- a/api.js
+++ b/api.js
@@ -6,12 +6,12 @@ module.exports = function (req, res, next) {
         var params = req.query,
             api_key = params.api_key || gauthkey,
             id = params.id,
-            sheet = params.sheet || 1,
+            sheet = params.sheet,
             query = params.q,
             useIntegers = params.integers || true,
             showRows = params.rows || true,
             showColumns = params.columns || true,
-            url = 'https://sheets.googleapis.com/v4/spreadsheets/' + id + '/values/Sheet' + sheet + '?key=' + api_key;
+            url = 'https://sheets.googleapis.com/v4/spreadsheets/' + id + '/values/' + sheet + '?key=' + api_key;
         request(url, function (error, response, body) {
             if (!error && response.statusCode === 200) {
                 var data = JSON.parse(response.body);


### PR DESCRIPTION
The Sheets API takes in the name of the specific sheet instead of an index.